### PR TITLE
Clips are now loaded in chunks

### DIFF
--- a/components/clips/clip-editor.tsx
+++ b/components/clips/clip-editor.tsx
@@ -108,6 +108,11 @@ export default function ClipEditor({ clip, wavBuffer, audioSrc }: ClipEditorProp
     setSound(newSound)
     newSound.play()
     Howler.volume(0.5)
+    return () => {
+      if (sound) {
+        sound.stop()
+      }
+    }
   }, [wavBuffer, audioSrc])
 
   useEffect(() => {

--- a/pages/api/clipdata/[clipid].ts
+++ b/pages/api/clipdata/[clipid].ts
@@ -1,0 +1,52 @@
+import S3 from "aws-sdk/clients/s3"
+
+import { Clip } from "../../../types/models"
+import { ClipModel } from "../../../utils/db/models/clips"
+import { Database } from "../../../utils/db/db"
+
+const MAX_RESPONSE_SIZE = 1023996 // multiple of 3 for clean conversion to base64
+
+const s3 = new S3({
+  accessKeyId: process.env.SITE_AWS_ACCESS_KEY_ID,
+  secretAccessKey: process.env.SITE_AWS_SECRET
+})
+
+async function getClipDataFromS3(clipid: string, start: number, end: number): Promise<Buffer> {
+  const params = {
+    Bucket: process.env.SITE_AWS_S3_BUCKET,
+    Key: `clips/${clipid}.pcm`,
+    Range: `bytes=${start}-${end}`
+  }
+
+  const data = await s3.getObject(params).promise()
+  return data.Body as Buffer
+}
+
+// Cache clip durations - prevents multiple calls to the db when streaming the clip data
+const clipDurationCache = new Map<string, number>()
+export default async (req, res) => {
+  const clipid: string = req.query.clipid
+  const start: number = req.query.start ? +req.query.start : 0
+
+  try {
+    let duration: number;
+    if (clipDurationCache.has(clipid)) {
+      duration = clipDurationCache.get(clipid)
+    } else {
+      const clip = await ClipModel(Database()).getClip(clipid)
+      duration = clip.duration
+      clipDurationCache.set(clipid, duration)
+    }
+    const end = Math.min(duration, start + MAX_RESPONSE_SIZE - 1)
+    const clipData = await getClipDataFromS3(clipid, start, end)
+    res.status(200).json({
+      data: clipData.toString('base64'),
+      ptr: end + 1,
+      duration: duration,
+      done: (end >= duration)
+    })
+  } catch (err) {
+    console.error(err)
+    res.status(500).json('Unexpected error when getting clip')
+  }
+}

--- a/pages/api/clips/[clipid].ts
+++ b/pages/api/clips/[clipid].ts
@@ -1,23 +1,6 @@
-import S3 from "aws-sdk/clients/s3"
-
 import { Clip } from "../../../types/models"
 import { ClipModel } from "../../../utils/db/models/clips"
 import { Database } from "../../../utils/db/db"
-
-const s3 = new S3({
-  accessKeyId: process.env.SITE_AWS_ACCESS_KEY_ID,
-  secretAccessKey: process.env.SITE_AWS_SECRET
-})
-
-async function getClipDataFromS3(clip: Clip): Promise<Buffer> {
-  const params = {
-    Bucket: process.env.SITE_AWS_S3_BUCKET,
-    Key: `clips/${clip.id}.pcm`
-  }
-
-  const data = await s3.getObject(params).promise()
-  return data.Body as Buffer
-}
 
 export default async (req, res) => {
   const {
@@ -25,11 +8,7 @@ export default async (req, res) => {
   } = req
   try {
     const clip = await ClipModel(Database()).getClip(clipid)
-    const clipData = await getClipDataFromS3(clip)
-    res.status(200).json({
-      ...clip,
-      data: clipData.toString('base64')
-    })
+    res.status(200).json(clip)
   } catch (err) {
     console.error(err)
     res.status(500).json('Unexpected error when getting clip')


### PR DESCRIPTION
`/api/clipdata/:clipid` now retrieves the s3 data in chunks of ~1MB and returns it as base64 encoded strings, which are then assembled client side into a single buffer. `/api/clip/:clipid` no longer returns the full clip data.